### PR TITLE
fix add task title input autofocus

### DIFF
--- a/client/views/layout/layout.html
+++ b/client/views/layout/layout.html
@@ -1,9 +1,8 @@
 <template name="layout">
   {{#if modalActive}}
     <div class="app-dimmer"></div>
+    {{> addTask}}
   {{/if}}
-
-  {{> addTask}}
 
   {{> Template.dynamic template=header}}
   {{> Template.dynamic template=nav}}

--- a/client/views/tasks/addTask/addTask.js
+++ b/client/views/tasks/addTask/addTask.js
@@ -7,8 +7,9 @@ function itemType () {
   return 'task';
 }
 
-View.onCreated(function () {
+View.onRendered(function () {
   rankVar.set(1);
+  $('.app-addtask__content--title').focus();
 });
 
 View.helpers({


### PR DESCRIPTION
Closes #64 

- only render addTask if modalActive
- move rankVar init to onRendered
- focus on add task title input when add task template renders